### PR TITLE
feat: Allow re-sending reports and remove admin restrictions

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         finalizeBtn.addEventListener('click', () => {
             const date = dateSelector.value;
-            if (confirm(`¿Está seguro de finalizar la programación para el ${date}?\n\nEsta acción enviará los reportes y no se podrá revertir.`)) {
+            if (confirm(`¿Está seguro de finalizar la programación para el ${date}?\n\nEsta acción enviará los reportes a todos los involucrados. Puede realizar esta acción cuantas veces sea necesario para ajustar la programación.`)) {
                 finalizeBtn.disabled = true;
                 finalizeBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Finalizando...';
                 


### PR DESCRIPTION
This commit introduces two main changes to the admin dashboard:

1.  The "Finalizar y Enviar Reportes" button now allows sending reports multiple times. This is useful when an administrator needs to edit a record and resend the reports with the adjustments. The queries have been updated to include all records for the selected date, regardless of their status.

2.  The restriction that prevented administrators from adding new manual records after a day was finalized has been removed. This provides more flexibility for the administrator. The restriction is still active for regular users submitting the public form.